### PR TITLE
feat: Pass options to babel-preset-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ equals
 ### `target`
 
 `"node" | "browser"`, defaults to `"node"`
+
+**All other options are passed directly to [babel-preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env)**

--- a/package-lock.json
+++ b/package-lock.json
@@ -638,29 +638,6 @@
         "write-pkg": "3.1.0"
       }
     },
-    "babel-cli": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
-      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.0",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "commander": "2.11.0",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
-      }
-    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -1660,12 +1637,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "comment-parser": {
@@ -2898,12 +2869,6 @@
       "requires": {
         "null-check": "1.0.0"
       }
-    },
-    "fs-readdir-recursive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -5321,17 +5286,6 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "output-file-sync": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
-    },
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
@@ -5961,6 +5915,12 @@
       "requires": {
         "glob": "7.1.2"
       }
+    },
+    "rollup": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.52.1.tgz",
+      "integrity": "sha512-cVOL8rUMivChVcScL7zq1JCl4+4gMiVOllnX9r2l6MlkUzyXRbBK7szGDGaFXyqZl6uruFtX+gFhize9o7iiKg==",
+      "dev": true
     },
     "run-async": {
       "version": "2.3.0",
@@ -6682,12 +6642,6 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
     },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-      "dev": true
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6699,15 +6653,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
       "dev": true
-    },
-    "v8flags": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@commitlint/config-angular": "^4.3.0",
     "@ls-age/eslint-config": "^0.4.0",
     "ava": "^0.23.0",
+    "babel-core": "^6.26.0",
     "babel-register": "^6.26.0",
     "conventional-changelog-cli": "^1.3.5",
     "conventional-github-releaser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Babel preset used by ls-age",
   "main": "out",
   "scripts": {
-    "compile": "babel -d out src",
+    "compile": "rollup src/index.js --output.format cjs --external babel-preset-env --output.file out/index.js",
     "commitmsg": "commitlint -p @commitlint/config-angular -e $GIT_PARAMS",
     "lint": "eslint src test",
     "test": "ava"
@@ -24,13 +24,12 @@
     "@commitlint/config-angular": "^4.3.0",
     "@ls-age/eslint-config": "^0.4.0",
     "ava": "^0.23.0",
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
     "babel-register": "^6.26.0",
     "conventional-changelog-cli": "^1.3.5",
     "conventional-github-releaser": "^2.0.0",
     "eslint": "^4.11.0",
     "husky": "^0.14.3",
+    "rollup": "^0.52.1",
     "standard-version": "^4.2.0",
     "tap-xunit": "^1.7.0"
   },
@@ -41,9 +40,7 @@
     "extends": "@ls-age"
   },
   "babel": {
-    "presets": [
-      "./registered"
-    ]
+    "presets": "./out/index.js"
   },
   "ava": {
     "require": [

--- a/registered.js
+++ b/registered.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-commonjs */
 require('babel-register')({
   presets: [
     'env',

--- a/registered.js
+++ b/registered.js
@@ -1,8 +1,0 @@
-/* eslint-disable import/no-commonjs */
-require('babel-register')({
-  presets: [
-    'env',
-  ],
-});
-
-module.exports = require('./src/node');

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,11 +1,5 @@
-import envPreset from './lib/envPreset';
-
 export default {
-  presets: [
-    envPreset({
-      browsers: [
-        '> 1%',
-      ],
-    }),
+  browsers: [
+    '> 1%',
   ],
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,19 @@
 import node from './node';
 import browser from './browser';
+import envPreset from './lib/envPreset';
 
 export default function(api, target = 'node') {
-  return [target, target.target].includes('browser') ?
-    browser :
-    node;
+  const targets = [target, target.target].includes('browser') ? browser : node;
+  let options;
+
+  if (typeof target === 'object') {
+    options = Object.assign({}, target);
+    delete options.target;
+  }
+
+  return {
+    presets: [
+      envPreset(targets, options),
+    ],
+  };
 }

--- a/src/lib/envPreset.js
+++ b/src/lib/envPreset.js
@@ -1,8 +1,8 @@
 import envPreset from 'babel-preset-env';
 
-export default function envPresetWithTargets(targets) {
+export default function envPresetWithTargets(targets, options = {}) {
   return [
     envPreset,
-    { targets },
+    Object.assign({ targets }, options),
   ];
 }

--- a/src/node.js
+++ b/src/node.js
@@ -1,7 +1,3 @@
-import envPreset from './lib/envPreset';
-
 export default {
-  presets: [
-    envPreset({ node: 8 }),
-  ],
+  node: 8,
 };

--- a/test/test.js
+++ b/test/test.js
@@ -23,9 +23,21 @@ test('doesn\'t transforms async functions on browser target', t => {
 });
 
 test('node is default target', t => {
-  t.is(lsPreset(), lsPreset({}, 'node'));
+  t.deepEqual(lsPreset(), lsPreset({}, 'node'));
 });
 
 test('options object should work', t => {
-  t.is(lsPreset({}, 'node'), lsPreset({}, { target: 'node' }));
+  t.deepEqual(lsPreset({}, 'node'), lsPreset({}, { target: 'node' }));
+});
+
+test('babel-preset-env options are bypassed', t => {
+  const preset = lsPreset({}, { target: 'node', modules: false });
+
+  t.is(preset.presets[0][1].modules, false);
+});
+
+test('targets can be overridden', t => {
+  const preset = lsPreset({}, { targets: { node: 13 } });
+
+  t.is(preset.presets[0][1].targets.node, 13);
 });


### PR DESCRIPTION
From now on options are passed to `babel-preset-env` to allow preset overrides.